### PR TITLE
Refactor BUILDER.ipynb and remove legacy Project-M Colab cells

### DIFF
--- a/BUILDER.ipynb
+++ b/BUILDER.ipynb
@@ -2001,136 +2001,44 @@
     {
       "cell_type": "code",
       "source": [
-        "# @title 🔨 Project-M sh\n",
+        "# @title 🔨 Project-M\n",
         "import os\n",
         "\n",
-        "# --- CONFIGURATION ---\n",
-        "PROJECT_NAME = \"Project-M\" # @param [\"mod-player\", \"your-other-project-name\"] # Customize with your project names\n",
+        "PROJECT_ROOT = \"/content/build_space/projectm\"\n",
+        "GIT_REPO = \"https://github.com/ford442/Project-M.git\"\n",
+        "BRANCH = \"main\"  # @param {type:\"string\"}\n",
         "\n",
-        "GIT_REPO = f\"https://github.com/ford442/{PROJECT_NAME}.git\" # <--- CHANGE THIS TO YOUR REPO URL\n",
-        "USE_EMSDK = False # Set to True if you need C++\n",
-        "# ---------------------\n",
+        "# Optional: set before running build cell\n",
+        "# os.environ[\"RUN_OPTIMIZE\"] = \"1\"       # run optimize.sh after bundle staging\n",
+        "# os.environ[\"BUILD_JOBS\"] = \"8\"\n",
+        "# os.environ[\"ENABLE_WASM_TRANSITIONS\"] = \"ON\"\n",
         "\n",
-        "target_dir = f\"/content/build_space/projectm\"\n",
-        "\n",
-        "# Clone if not exists, otherwise pull latest changes\n",
-        "if not os.path.exists(target_dir):\n",
+        "if not os.path.exists(PROJECT_ROOT):\n",
         "    print(f\"⬇️ Cloning {GIT_REPO}...\")\n",
-        "    !git clone {GIT_REPO} {target_dir} --recursive\n",
+        "    !git clone --recursive {GIT_REPO} {PROJECT_ROOT}\n",
         "else:\n",
-        "    print(f\"🔄 Repository {PROJECT_NAME} already exists. Pulling latest changes...\")\n",
-        "    %cd {target_dir}\n",
-        "    !git pull\n",
+        "    print(\"🔄 Pulling latest...\")\n",
+        "    %cd {PROJECT_ROOT}\n",
+        "    !git pull --recurse-submodules\n",
         "\n",
-        "%cd {target_dir}\n",
+        "%cd {PROJECT_ROOT}\n",
+        "!git checkout {BRANCH}\n",
+        "!git submodule update --init --recursive\n",
+        "!git pull --recurse-submodules\n",
         "\n",
-        "!git checkout main\n",
-        "#!git checkout main-dev2\n",
-        "#!git checkout stack-shaders-13277186508483700298\n",
-        "#!git checkout copilot/implement-advanced-shaders\n",
-        "#!git checkout fix-wgsl-compute-derivatives\n",
-        "#!git checkout feature/rain-shader\n",
-        "!git pull\n",
+        "print(\"🚀 Building via scripts/colab_build.sh (aligned with repo CI)...\")\n",
+        "!chmod +x scripts/colab_build.sh scripts/colab_deploy.sh\n",
+        "!{PROJECT_ROOT}/scripts/colab_build.sh\n",
         "\n",
-        "# --- BUILD COMMANDS ---\n",
-        "# Modify the section below based on your project needs\n",
-        "print(\"🚀 Starting Build...\")\n",
+        "print(\"📦 Deploying via scripts/colab_deploy.sh...\")\n",
+        "!{PROJECT_ROOT}/scripts/colab_deploy.sh\n",
         "\n",
-        "if USE_EMSDK:\n",
-        "    # Example C++ Build\n",
-        "    !source /content/build_space/emsdk/emsdk_env.sh && npm install && npm run build\n",
-        "\n",
-        "else:\n",
-        "    # Standard NPM Build\n",
-        "    !chmod 0777 /content/build_space/projectm/scripts/colab_build.sh\n",
-        "    !/content/build_space/projectm/scripts/colab_build.sh\n",
-        "    #!npm install\n",
-        "    #!npm install hls.js --save\n",
-        "    #!npm run build\n",
-        "    !/content/build_space/projectm/scripts/colab_deploy.sh\n",
-        "\n",
-        "print(\"✅ Build Complete.\")\n",
-        "\n",
-        "import os\n",
-        "\n",
-        "# --- CONFIGURATION ---\n",
-        "# PROJECT_NAME is defined in a previous cell and inherited here.\n",
+        "print(\"✅ Project-M build and deploy complete.\")\n",
         ""
       ],
       "metadata": {
         "id": "_BK911vIs7Ic",
         "collapsed": true,
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# @title 🔨 projectm safe\n",
-        "%%shell\n",
-        "export JVM_HEAP_SIZE=8g\n",
-        "source /content/build_space/emsdk/emsdk_env.sh\n",
-        "cd /content/build_space/projectm\n",
-        "git checkout new\n",
-        "emcc /content/build_space/projectm/projectM_emscripten.cpp \\\n",
-        "    -I /usr/local/include -sUSE_SDL=2 \\\n",
-        "    -l embind --bind -O3 \\\n",
-        "    -o projectm.js \\\n",
-        "    -s ALLOW_MEMORY_GROWTH=0 -sINITIAL_MEMORY=3221225472 \\\n",
-        "    -s ENVIRONMENT=web \\\n",
-        "    -s EXPORTED_FUNCTIONS=_add_audio_data,_main,_pl \\\n",
-        "    -s EXPORTED_RUNTIME_METHODS=ccall \\\n",
-        "    -s EXPORT_NAME=createModule \\\n",
-        "    -s FULL_ES2=1 -s FULL_ES3=1 \\\n",
-        "    -s MIN_WEBGL_VERSION=2 -s MAX_WEBGL_VERSION=2 \\\n",
-        "    -s MODULARIZE=1 \\\n",
-        "    -s FORCE_FILESYSTEM=1 \\\n",
-        "    /content/build_space/projectm/build/src/libprojectM/libprojectM-4.a"
-      ],
-      "metadata": {
-        "id": "0Hdjnt0zmVsF",
-        "cellView": "form",
-        "collapsed": true
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# @title\n",
-        "%%shell\n",
-        "export JVM_HEAP_SIZE=8g\n",
-        "source /content/build_space/emsdk/emsdk_env.sh\n",
-        "cd /content/build_space/projectm\n",
-        "#git checkout jules-1-14-26\n",
-        "git checkout main\n",
-        "git pull\n",
-        "em++ /content/build_space/projectm/projectM_emscripten.cpp \\\n",
-        "    -I /usr/local/include -sUSE_SDL=2 -DNDEBUG=1 -std=c++26 \\\n",
-        "    -mtune=wasm32 -msse -msse2 -msse3 -mssse3 -msse4 -msse4.1 -msse4.2 -mavx -msimd128 -mavx2 \\\n",
-        "    -l embind -O2 --bind -ffast-math -mextended-const -mbulk-memory \\\n",
-        "    -o projectm-v.030-thread.js -fPIC -fPIE -dead_strip -sWASM_BIGINT=1 -sSUPPORT_ERRNO=0 \\\n",
-        "    -fno-strict-aliasing -ffinite-math-only -fexcess-precision=fast -sGL_TRACK_ERRORS=0 \\\n",
-        "    -funsafe-math-optimizations -fno-trapping-math -ffp-contract=fast \\\n",
-        "    -s ALLOW_MEMORY_GROWTH=1 -ffunction-sections -fdata-sections \\\n",
-        "    -s ENVIRONMENT=web -sASSERTIONS=0 -s NO_DISABLE_EXCEPTION_CATCHING=1 \\\n",
-        "    -s EXPORTED_FUNCTIONS=_add_audio_data,_main,_pl -sGL_MAX_TEMP_BUFFER_SIZE=33177600 \\\n",
-        "    -s EXPORTED_RUNTIME_METHODS=ccall -sSUPPORT_LONGJMP=emscripten \\\n",
-        "    -sABORT_ON_WASM_EXCEPTIONS=0 -sEMULATE_FUNCTION_POINTER_CASTS=1 -sTEXTDECODER=2 -sEMBIND_STD_STRING_IS_UTF8=0 \\\n",
-        "    -s EXPORT_NAME=createModule -sMALLOC='mimalloc' \\\n",
-        "    -s USE_WEBGL2=1 -s FULL_ES2=1 -s FULL_ES3=1 -lGL -lEGL \\\n",
-        "    -rtlib=compiler-rt  -s PTHREAD_POOL_SIZE=4 -sWASMFS=1 \\\n",
-        "    -s MIN_WEBGL_VERSION=2 -s MAX_WEBGL_VERSION=2 \\\n",
-        "    -s MODULARIZE=1 -sTRUSTED_TYPES=1 -sALLOW_UNIMPLEMENTED_SYSCALLS=0 -sIGNORE_MISSING_MAIN=0 \\\n",
-        "    -s FORCE_FILESYSTEM=1 -sWASM_LEGACY_EXCEPTIONS=0 -sEVAL_CTORS=2 \\\n",
-        "    -L/usr/local/lib -lprojectM-4 -lprojectM-4-playlist -fopenmp /content/build_space/projectm/libomp.a\n",
-        "    # --closure 0 \\"
-      ],
-      "metadata": {
-        "id": "q_Un_nvbmagY",
         "cellView": "form"
       },
       "execution_count": null,
@@ -4298,259 +4206,6 @@
       ],
       "metadata": {
         "id": "iw6BfyBQUcj6",
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Project-M WASM"
-      ],
-      "metadata": {
-        "id": "fQ5CCJVWc-j5"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# @title\n",
-        "%%shell\n",
-        "sudo aptitude install bison -y\n",
-        "sudo aptitude install flex -y\n",
-        "sudo aptitude install cmake-curses-gui -y\n",
-        "sudo aptitude install qtbase5-dev -y  # For building Qt-based UIs\n",
-        "sudo aptitude install llvm-dev -y  # for using the experimental LLVM Jit\n",
-        "sudo aptitude install libvisual-0.4-dev -y  # To build the libvisual plug-in\n",
-        "sudo aptitude install ninja-build -y  # To build projectM with Ninja instead of make"
-      ],
-      "metadata": {
-        "id": "j_IJcIRpk13b",
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# @title\n",
-        "%%shell\n",
-        "export JVM_HEAP_SIZE=8g\n",
-        "source /content/build_space/emsdk/emsdk_env.sh\n",
-        "git clone  https://github.com/ford442/Project-M.git --recursive /content/build_space/projectm\n",
-        "\n",
-        "#git checkout 5ef0dcdf801eb91e295d4204a8abb8dcc44bcc25\n",
-        "#git checkout main\n",
-        "#git checkout 5ef0dcdf801eb91e295d4204a8abb8dcc44bcc25\n",
-        "\n",
-        "# 4. IMPORTANT: Sync submodules to the state required by this commit\n",
-        "#git submodule update --init --recursive\n",
-        "\n",
-        "cd /content/build_space/projectm\n",
-        "#git pull\n",
-        "#git checkout webaudio_test\n",
-        "#git checkout Jules_61525\n",
-        "#git checkout jules_update\n",
-        "#git checkout jules-1-14-26\n",
-        "\n",
-        "git pull"
-      ],
-      "metadata": {
-        "id": "UeWV9fNUkt9o",
-        "collapsed": true
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# @title\n",
-        "%%shell\n",
-        "export JVM_HEAP_SIZE=8g\n",
-        "source /content/build_space/emsdk/emsdk_env.sh\n",
-        "cd /content/build_space/projectm/vendor/projectm-eval\n",
-        "mkdir build\n",
-        "cd build\n",
-        "cmake ..\n",
-        "make install -j8"
-      ],
-      "metadata": {
-        "id": "E11HlPIxlCja",
-        "collapsed": true
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# @title\n",
-        "%%shell\n",
-        "cd /content/build_space/projectm\n",
-        "mkdir build\n",
-        "cd build\n",
-        "source /content/build_space/emsdk/emsdk_env.sh\n",
-        "CMAKE_MODULE_PATH+=/usr/local/lib/cmake/projectM-Eval/"
-      ],
-      "metadata": {
-        "id": "6J644M-rlJFe",
-        "collapsed": true
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "#! cp /usr/lib/llvm-14/lib/clang/14.0.0/include/omp.h /content/build_space/projectm/src/libprojectM/omp.h\n",
-        "#! cp /usr/lib/llvm-14/lib/clang/14.0.0/include/omp.h /usr/local/include/omp.h\n",
-        "!cp /content/build_space/projectm/omp/* /content/build_space/projectm/\n",
-        "!unzip -o /content/build_space/projectm/omp.zip -d /content/build_space/projectm/"
-      ],
-      "metadata": {
-        "id": "OJh0vSf6lJDK",
-        "collapsed": true
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# @title\n",
-        "%%shell\n",
-        "export JVM_HEAP_SIZE=8g\n",
-        "source /content/build_space/emsdk/emsdk_env.sh\n",
-        "cd /content/build_space/projectm/build\n",
-        "git pull\n",
-        "\n",
-        "emcmake cmake .. -DCMAKE_BUILD_TYPE=Release  -DENABLE_OPENMP=ON -D CMAKE_INSTALL_PREFIX=/usr/local -DSDL_PTHREADS=1 -DUSE_PTHREADS=1 -DBOOST_HAS_THREADS=1 -DBOOST_UBLAS_USE_LONG_DOUBLE=1 -DBOOST_UBLAS_NDEBUG=1 -DENABLE_EMSCRIPTEN=1 -DENABLE_GLES=1 -DBUILD_SHARED_LIBS=0 -DENABLE_CXX_INTERFACE=1 -DCMAKE_MODULE_PATH=\"/usr/local/lib/cmake/projectM-Eval/\"\n",
-        "\n",
-        "emmake cmake --build . --target install --config Release    -j8"
-      ],
-      "metadata": {
-        "id": "47apN7p3lSga",
-        "collapsed": true
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "%%shell\n",
-        "export JVM_HEAP_SIZE=8g\n",
-        "source /content/build_space/emsdk/emsdk_env.sh\n",
-        "cd /content/build_space/projectm\n",
-        "git pull\n",
-        "emcc /content/build_space/projectm/projectM_emscripten.cpp \\\n",
-        "    -I /usr/local/include -O3 \\\n",
-        "    -l embind -pthread -fopenmp libomp.a -o projectm-v.035-thread.js \\\n",
-        "    -s ALLOW_MEMORY_GROWTH=1 -sNO_DISABLE_EXCEPTION_CATCHING=1 \\\n",
-        "    -s ENVIRONMENT=web,worker -sSHARED_MEMORY=1 \\\n",
-        "    -s EXPORTED_FUNCTIONS=_add_audio_data,_main,_pl,_destruct,_get_projectm_handle,_init,_load_preset_file,_switch_preset,_set_aspect_correction,_render_frame,_start_render,_set_window_size,_set_mesh,_add_preset_path,_add_existing_vfs_presets,_add_preset_file,_add_custom_milk_paths,_projectm_pcm_add_float_wrapper,_create_sprite,_stop_worklet_playback,_set_audio_source_to_stream \\\n",
-        "    -s EXPORTED_RUNTIME_METHODS=ccall,FS \\\n",
-        "    -s PTHREAD_POOL_SIZE=4 -s ASYNCIFY=1 -sASYNCIFY_IMPORTS=emscripten_sleep \\\n",
-        "    -s FULL_ES2=1 -s FULL_ES3=1 \\\n",
-        "    -s MIN_WEBGL_VERSION=2 -s MAX_WEBGL_VERSION=2 \\\n",
-        "    -s MODULARIZE=1 -s EXPORT_NAME=createModule \\\n",
-        "    -s FORCE_FILESYSTEM=1 -s WASMFS=1 \\\n",
-        "    /content/build_space/projectm/build/src/libprojectM/libprojectM-4.a \\\n",
-        "    /content/build_space/projectm/build/src/playlist/libprojectM-4-playlist.a\n",
-        ""
-      ],
-      "metadata": {
-        "id": "AI8fqGc5lVLi",
-        "collapsed": true
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "!bash /content/build_space/projectm/optimize.sh"
-      ],
-      "metadata": {
-        "id": "q_aDkySUGwj7",
-        "collapsed": true
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "!iconv -f UTF-8 -t UTF-16 /content/build_space/projectm/projectm-v.035-thread.js -o /content/build_space/projectm/projectm-v.035-thread.1ijs\n",
-        "!iconv -f UTF-8 -t UTF-32 /content/build_space/projectm/projectm-v.035-thread.js -o /content/build_space/projectm/projectm-v.035-thread.3ijs"
-      ],
-      "metadata": {
-        "id": "YSGKhDxdlXSK"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "loc_file1 = \"projectm-v.035-thread.1ijs\" #@param [\"sh4.1ijs\", \"sh5.1ijs\", \"g3007.wasm\", \"g3008.wasm\", \"g3009.wasm\", \"sh6.1ijs\", \"g3010.wasm\"] {allow-input: true}\n",
-        "loc_file2 = \"projectm-v.035-thread.wasm\" #@param [\"sh4.1ijs\", \"sh5.1ijs\", \"g3007.wasm\", \"g3008.wasm\", \"g3009.wasm\", \"sh6.1ijs\", \"g3010.wasm\"] {allow-input: true}\n",
-        "import os\n",
-        "import urllib\n",
-        "import requests as reqs\n",
-        "import re\n",
-        "import paramiko\n",
-        "host = \"1ink.us\"\n",
-        "username = os.environ.get(\"DEPLOY_USER\", os.environ.get(\"SFTP_USER\", \"\"))\n",
-        "password = os.environ.get(\"DEPLOY_PASS\", os.environ.get(\"SFTP_PASSWORD\", \"\"))\n",
-        "port = 22\n",
-        "file_name=loc_file1\n",
-        "local_path=\"/content/build_space/projectm/\"+file_name\n",
-        "transport = paramiko.Transport((host, port))\n",
-        "destination_path=\"wasm.noahcohn.com/pm/\"+file_name\n",
-        "destination_path2=\"noahcohn.com/pm/\"+file_name\n",
-        "transport.connect(username = username, password = password)\n",
-        "sftp = paramiko.SFTPClient.from_transport(transport)\n",
-        "sftp.put(local_path, destination_path)\n",
-        "sftp.put(local_path, destination_path2)\n",
-        "sftp.close()\n",
-        "transport.close()\n",
-        "file_name2=loc_file2\n",
-        "local_path=\"/content/build_space/projectm/\"+file_name2\n",
-        "transport = paramiko.Transport((host, port))\n",
-        "destination_path=\"wasm.noahcohn.com/pm/\"+file_name2\n",
-        "destination_path2=\"noahcohn.com/pm/\"+file_name2\n",
-        "transport.connect(username = username, password = password)\n",
-        "sftp = paramiko.SFTPClient.from_transport(transport)\n",
-        "sftp.put(local_path, destination_path)\n",
-        "sftp.put(local_path, destination_path2)\n",
-        "sftp.close()\n",
-        "transport.close()\n",
-        "loc_file3 = \"projectm-v.035-thread.3ijs\" #@param [\"sh4.1ijs\", \"sh5.1ijs\", \"g3007.wasm\", \"g3008.wasm\", \"g3009.wasm\", \"sh6.1ijs\", \"g3010.wasm\"] {allow-input: true}\n",
-        "import os\n",
-        "import urllib\n",
-        "import requests as reqs\n",
-        "import re\n",
-        "import paramiko\n",
-        "host = \"1ink.us\"\n",
-        "username = os.environ.get(\"DEPLOY_USER\", os.environ.get(\"SFTP_USER\", \"\"))\n",
-        "password = os.environ.get(\"DEPLOY_PASS\", os.environ.get(\"SFTP_PASSWORD\", \"\"))\n",
-        "port = 22\n",
-        "file_name=loc_file3\n",
-        "local_path=\"/content/build_space/projectm/\"+file_name\n",
-        "transport = paramiko.Transport((host, port))\n",
-        "destination_path=\"wasm.noahcohn.com/pm/\"+file_name\n",
-        "transport.connect(username = username, password = password)\n",
-        "sftp = paramiko.SFTPClient.from_transport(transport)\n",
-        "sftp.put(local_path, destination_path)\n",
-        "sftp.close()\n",
-        "transport.close()"
-      ],
-      "metadata": {
-        "id": "xhW8umURlX7w",
         "cellView": "form"
       },
       "execution_count": null,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

BUILDER.ipynb cleanup: secrets/helpers refactor plus removal of legacy Project-M Colab cells.

## Project-M cleanup (latest commit)

- **Removed 13 cells:** manual cmake/emcc pipeline, `optimize.sh`/iconv, paramiko SFTP deploy, experimental `projectm safe` / `em++` links, and the `# Project-M WASM` section
- **Single canonical cell** now clones/pulls Project-M and runs:
  - `scripts/colab_build.sh` (CI-aligned WASM build)
  - `scripts/colab_deploy.sh` (token-based deploy via `deploy.py`)

## Earlier changes in this branch

- Colab secrets for deploy credentials and API keys (no hardcoded passwords/keys)
- Shared build/deploy helper cell; 28 standard project cells converted to DRY pattern
- Path bug fixes, setup repairs (WasmEdge, GLM, assimp), 6GB RAM drive default
- `scripts/refactor_builder_notebook.py` for repeatable notebook maintenance

**Action required:** Rotate any previously exposed credentials and add them to Colab Secrets.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a4eefcf-44dd-4425-8f43-80a0b6fc9280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a4eefcf-44dd-4425-8f43-80a0b6fc9280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

